### PR TITLE
Fix some warnings and sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Spawns an arbitrary TCP server temporarily with an automatically retrieved port.
 #include "glint.h"
 
 // Assume the server is the target of your integration test
-void my_glint_callback(uint16_t port) {
+void my_glint_callback(char *port) {
   execl("tests/test-server.rb", "ruby", port, (char *)NULL);
 }
 

--- a/glint.h
+++ b/glint.h
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 typedef void (*glint_callback)(char *port);

--- a/glint.h
+++ b/glint.h
@@ -84,7 +84,7 @@ bool glint_start(glint *self) {
       int sock;
       if ((sock = socket(PF_INET, SOCK_STREAM, 0)) < 0) {
         perror("failed to create a socket");
-        false;
+        return false;
       }
 
       if (connect(sock, (struct sockaddr *)&server, sizeof(server)) < 0) {


### PR DESCRIPTION
- Include missing header files for Linux(https://linux.die.net/man/2/waitpid)
- Fix missing `return`
- Fix sample code